### PR TITLE
Throw an exception when the serializer fails

### DIFF
--- a/EventListener/SerializerListener.php
+++ b/EventListener/SerializerListener.php
@@ -30,10 +30,7 @@ class SerializerListener
                     break;
             }
         } catch (BaseSerializerException $e) {
-            throw new BadRequestHttpException(
-                sprintf('The content of the request cannot be deserialized into a valid xAPI %s.', $request->attributes->get('xapi_serializer')),
-                $e
-            );
+            throw new BadRequestHttpException(sprintf('The content of the request cannot be deserialized into a valid xAPI %s.', $request->attributes->get('xapi_serializer')), $e);
         }
     }
 }

--- a/EventListener/SerializerListener.php
+++ b/EventListener/SerializerListener.php
@@ -3,6 +3,8 @@
 namespace XApi\LrsBundle\EventListener;
 
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Serializer\Exception\ExceptionInterface as BaseSerializerException;
 use Symfony\Component\Serializer\SerializerInterface;
 
 /**
@@ -21,10 +23,17 @@ class SerializerListener
     {
         $request = $event->getRequest();
 
-        switch ($request->attributes->get('xapi_serializer')) {
-            case 'statement':
-                $request->attributes->set('statement', $this->serializer->deserialize($request->getContent(), 'Xabbuh\XApi\Model\Statement', 'json'));
-                break;
+        try {
+            switch ($request->attributes->get('xapi_serializer')) {
+                case 'statement':
+                    $request->attributes->set('statement', $this->serializer->deserialize($request->getContent(), 'Xabbuh\XApi\Model\Statement', 'json'));
+                    break;
+            }
+        } catch (BaseSerializerException $e) {
+            throw new BadRequestHttpException(
+                sprintf('The content of the request cannot be deserialized into a valid xAPI %s.', $request->attributes->get('xapi_serializer')),
+                $e
+            );
         }
     }
 }

--- a/Spec/EventListener/SerializerListenerSpec.php
+++ b/Spec/EventListener/SerializerListenerSpec.php
@@ -11,12 +11,8 @@ use XApi\Fixtures\Json\StatementJsonFixtures;
 
 class SerializerListenerSpec extends ObjectBehavior
 {
-    function it_sets_unserialized_data_as_request_attributes(
-        SerializerInterface $serializer,
-        GetResponseEvent $event,
-        Request $request,
-        ParameterBag $attributes
-    ) {
+    function it_sets_unserialized_data_as_request_attributes(SerializerInterface $serializer, GetResponseEvent $event, Request $request, ParameterBag $attributes)
+    {
         $jsonString = StatementJsonFixtures::getTypicalStatement();
 
         $serializer->deserialize($jsonString, 'Xabbuh\XApi\Model\Statement', 'json')->shouldBeCalled();
@@ -33,12 +29,8 @@ class SerializerListenerSpec extends ObjectBehavior
         $this->onKernelRequest($event);
     }
 
-    function it_throws_a_badrequesthttpexception_if_the_serializer_fails(
-        SerializerInterface $serializer,
-        GetResponseEvent $event,
-        Request $request,
-        ParameterBag $attributes
-    ) {
+    function it_throws_a_badrequesthttpexception_if_the_serializer_fails(SerializerInterface $serializer, GetResponseEvent $event, Request $request, ParameterBag $attributes)
+    {
         $serializer->deserialize(null, 'Xabbuh\XApi\Model\Statement', 'json')->shouldBeCalled()->willThrow('\Symfony\Component\Serializer\Exception\InvalidArgumentException');
         $this->beConstructedWith($serializer);
 

--- a/Spec/EventListener/SerializerListenerSpec.php
+++ b/Spec/EventListener/SerializerListenerSpec.php
@@ -6,31 +6,50 @@ use PhpSpec\ObjectBehavior;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
-use Symfony\Component\HttpKernel\HttpKernelInterface;
-use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\SerializerInterface;
 use XApi\Fixtures\Json\StatementJsonFixtures;
 
 class SerializerListenerSpec extends ObjectBehavior
 {
-    function let(SerializerInterface $serializer)
-    {
+    function it_sets_unserialized_data_as_request_attributes(
+        SerializerInterface $serializer,
+        GetResponseEvent $event,
+        Request $request,
+        ParameterBag $attributes
+    ) {
+        $jsonString = StatementJsonFixtures::getTypicalStatement();
+
+        $serializer->deserialize($jsonString, 'Xabbuh\XApi\Model\Statement', 'json')->shouldBeCalled();
         $this->beConstructedWith($serializer);
-    }
 
-    function it_sets_unserialized_data_as_request_attributes()
-    {
-        $request = new Request();
-    }
+        $attributes->get('xapi_serializer')->willReturn('statement');
+        $attributes->set('statement', null)->shouldBeCalled();
 
-    function it_returns_a_400_response_if_the_serializer_fails(SerializerInterface $serializer, HttpKernelInterface $httpKernel, ParameterBag $parameterBag)
-    {
-        $json = StatementJsonFixtures::getTypicalStatement();
-        $request = new Request();
-        $request->attributes = $parameterBag;
-        $event = new GetResponseEvent($httpKernel, $request, HttpKernelInterface::MASTER_REQUEST);
-        $serializer->serialize($json, 'json')->willThrow(new InvalidArgumentException());
+        $request->attributes = $attributes;
+        $request->getContent()->shouldBeCalled()->willReturn($jsonString);
+
+        $event->getRequest()->willReturn($request);
 
         $this->onKernelRequest($event);
+    }
+
+    function it_throws_a_badrequesthttpexception_if_the_serializer_fails(
+        SerializerInterface $serializer,
+        GetResponseEvent $event,
+        Request $request,
+        ParameterBag $attributes
+    ) {
+        $serializer->deserialize(null, 'Xabbuh\XApi\Model\Statement', 'json')->shouldBeCalled()->willThrow('\Symfony\Component\Serializer\Exception\InvalidArgumentException');
+        $this->beConstructedWith($serializer);
+
+        $attributes->get('xapi_serializer')->willReturn('statement');
+
+        $request->attributes = $attributes;
+
+        $event->getRequest()->willReturn($request);
+
+        $this
+            ->shouldThrow('\Symfony\Component\HttpKernel\Exception\BadRequestHttpException')
+            ->during('onKernelRequest', array($event));
     }
 }


### PR DESCRIPTION
Still in a very early phase.

Still few questions left : 
- Should we throw a core Symfony exception or an exception from the php-xapi/exception package and implement a custom exception listener that will build the good `Response` for the exception ?

IMHO, we should use Symfony features since we are in the bundle and throw php-xapi specific exceptions only in the underneath libraries.
In that case, I feel that having a custom exception listener is kinda reinventing the wheel provided by the `HttpExceptionInterface` in `symfony/http-kernel` and the default exception listener.

- Shouldn't we throw exception in `StatementController` instead of returning directly a `Response` ? 

This will allow the exception listener to log what happened.