### PR TITLE
Support X-Experience-API-Version header in request/response

### DIFF
--- a/EventListener/VersionListener.php
+++ b/EventListener/VersionListener.php
@@ -36,7 +36,7 @@ class VersionListener
             throw new BadRequestHttpException('Missing required "X-Experience-API-Version" header.');
         }
 
-        if ($version === '1.0' || 0 === strpos($version, '1.0.')) {
+        if (preg_match('/^1\.0(?:\.\d+)?$/', $version)) {
             return;
         }
 

--- a/EventListener/VersionListener.php
+++ b/EventListener/VersionListener.php
@@ -33,7 +33,7 @@ class VersionListener
         }
 
         if (null === $version = $request->headers->get('X-Experience-API-Version')) {
-            throw new BadRequestHttpException('Missing required header "X-Experience-API-Version".');
+            throw new BadRequestHttpException('Missing required "X-Experience-API-Version" header.');
         }
 
         if ($version === '1.0' || 0 === strpos($version, '1.0.')) {

--- a/EventListener/VersionListener.php
+++ b/EventListener/VersionListener.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the xAPI package.
+ *
+ * (c) Christian Flothmann <christian.flothmann@xabbuh.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace XApi\LrsBundle\EventListener;
+
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+/**
+ * @author Jérôme Parmentier <jerome.parmentier@acensi.fr>
+ */
+class VersionListener
+{
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        if (!$event->isMasterRequest()) {
+            return;
+        }
+
+        $request = $event->getRequest();
+
+        if (!$request->attributes->has('xapi_lrs.route')) {
+            return;
+        }
+
+        if (null === $version = $request->headers->get('X-Experience-API-Version')) {
+            throw new BadRequestHttpException('Missing required header "X-Experience-API-Version".');
+        }
+
+        if ($version === '1.0' || 0 === strpos($version, '1.0.')) {
+            return;
+        }
+
+        throw new BadRequestHttpException(sprintf('xAPI version "%s" is not supported.', $version));
+    }
+
+    public function onKernelResponse(FilterResponseEvent $event)
+    {
+        if (!$event->isMasterRequest()) {
+            return;
+        }
+
+        if (!$event->getRequest()->attributes->has('xapi_lrs.route')) {
+            return;
+        }
+
+        $headers = $event->getResponse()->headers;
+
+        if (!$headers->has('X-Experience-API-Version')) {
+            $headers->set('X-Experience-API-Version', '1.0.3');
+        }
+    }
+}

--- a/EventListener/VersionListener.php
+++ b/EventListener/VersionListener.php
@@ -37,6 +37,10 @@ class VersionListener
         }
 
         if (preg_match('/^1\.0(?:\.\d+)?$/', $version)) {
+            if ('1.0' === $version) {
+                $request->headers->set('X-Experience-API-Version', '1.0.0');
+            }
+
             return;
         }
 

--- a/Resources/config/event_listener.xml
+++ b/Resources/config/event_listener.xml
@@ -16,5 +16,10 @@
             <argument type="service" id="xapi_lrs.statement.serializer" />
             <tag name="kernel.event_listener" event="kernel.request" />
         </service>
+
+        <service id="xapi_lrs.event_listener.version" class="XApi\LrsBundle\EventListener\VersionListener">
+            <tag name="kernel.event_listener" event="kernel.request" />
+            <tag name="kernel.event_listener" event="kernel.response" />
+        </service>
     </services>
 </container>

--- a/Spec/EventListener/VersionListenerSpec.php
+++ b/Spec/EventListener/VersionListenerSpec.php
@@ -54,7 +54,7 @@ class VersionListenerSpec extends ObjectBehavior
         $requestHeaders->get('X-Experience-API-Version')->shouldBeCalled()->willReturn(null);
 
         $this
-            ->shouldThrow(new BadRequestHttpException('Missing required header "X-Experience-API-Version".'))
+            ->shouldThrow(new BadRequestHttpException('Missing required "X-Experience-API-Version" header.'))
             ->during('onKernelRequest', array($getResponseEvent));
     }
 

--- a/Spec/EventListener/VersionListenerSpec.php
+++ b/Spec/EventListener/VersionListenerSpec.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Spec\XApi\LrsBundle\EventListener;
+
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\Component\HttpFoundation\HeaderBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+class VersionListenerSpec extends ObjectBehavior
+{
+    function let(GetResponseEvent $getResponseEvent, FilterResponseEvent $filterResponseEvent, Request $request, ParameterBag $attributes, HeaderBag $requestHeaders)
+    {
+        $attributes->has('xapi_lrs.route')->willReturn(true);
+
+        $request->attributes = $attributes;
+        $request->headers = $requestHeaders;
+
+        $getResponseEvent->isMasterRequest()->willReturn(true);
+        $getResponseEvent->getRequest()->willReturn($request);
+
+        $filterResponseEvent->isMasterRequest()->willReturn(true);
+        $filterResponseEvent->getRequest()->willReturn($request);
+    }
+
+    function it_returns_null_if_requests_are_not_master(GetResponseEvent $getResponseEvent, FilterResponseEvent $filterResponseEvent)
+    {
+        $getResponseEvent->isMasterRequest()->willReturn(false);
+        $getResponseEvent->getRequest()->shouldNotBeCalled();
+
+        $this->onKernelRequest($getResponseEvent)->shouldReturn(null);
+
+        $filterResponseEvent->isMasterRequest()->willReturn(false);
+        $filterResponseEvent->getRequest()->shouldNotBeCalled();
+
+        $this->onKernelResponse($filterResponseEvent)->shouldReturn(null);
+    }
+
+    function it_returns_null_if_not_xapi_route(GetResponseEvent $getResponseEvent, FilterResponseEvent $filterResponseEvent, ParameterBag $attributes)
+    {
+        $attributes->has('xapi_lrs.route')->shouldBeCalled()->willReturn(false);
+
+        $this->onKernelRequest($getResponseEvent)->shouldReturn(null);
+
+        $this->onKernelResponse($filterResponseEvent)->shouldReturn(null);
+    }
+
+    function it_throws_a_badrequesthttpexception_if_no_X_Experience_API_Version_header_is_set(GetResponseEvent $getResponseEvent, HeaderBag $requestHeaders)
+    {
+        $requestHeaders->get('X-Experience-API-Version')->shouldBeCalled()->willReturn(null);
+
+        $this
+            ->shouldThrow(new BadRequestHttpException('Missing required header "X-Experience-API-Version".'))
+            ->during('onKernelRequest', array($getResponseEvent));
+    }
+
+    function it_throws_a_badrequesthttpexception_if_specified_version_is_not_supported(GetResponseEvent $getResponseEvent, HeaderBag $requestHeaders)
+    {
+        $requestHeaders->get('X-Experience-API-Version')->shouldBeCalled()->willReturn('0.9.5');
+
+        $this
+            ->shouldThrow(new BadRequestHttpException('xAPI version "0.9.5" is not supported.'))
+            ->during('onKernelRequest', array($getResponseEvent));
+
+        $requestHeaders->get('X-Experience-API-Version')->shouldBeCalled()->willReturn('1.1.0');
+
+        $this
+            ->shouldThrow(new BadRequestHttpException('xAPI version "1.1.0" is not supported.'))
+            ->during('onKernelRequest', array($getResponseEvent));
+    }
+
+    function it_returns_null_if_version_is_supported(GetResponseEvent $getResponseEvent, HeaderBag $requestHeaders)
+    {
+        $requestHeaders->get('X-Experience-API-Version')->shouldBeCalled()->willReturn('1.0.0');
+
+        $this->onKernelRequest($getResponseEvent)->shouldReturn(null);
+    }
+
+    function it_sets_a_X_Experience_API_Version_header_in_response(FilterResponseEvent $filterResponseEvent, Response $response, HeaderBag $responseHeaders)
+    {
+        $responseHeaders->has('X-Experience-API-Version')->shouldBeCalled()->willReturn(false);
+        $responseHeaders->set('X-Experience-API-Version', '1.0.3')->shouldBeCalled();
+
+        $response->headers = $responseHeaders;
+
+        $filterResponseEvent->getResponse()->shouldBeCalled()->willReturn($response);
+
+        $this->onKernelResponse($filterResponseEvent);
+    }
+}

--- a/Spec/EventListener/VersionListenerSpec.php
+++ b/Spec/EventListener/VersionListenerSpec.php
@@ -73,6 +73,14 @@ class VersionListenerSpec extends ObjectBehavior
             ->during('onKernelRequest', array($getResponseEvent));
     }
 
+    function it_normalizes_the_X_Experience_API_Version_header(GetResponseEvent $getResponseEvent, HeaderBag $requestHeaders)
+    {
+        $requestHeaders->get('X-Experience-API-Version')->shouldBeCalled()->willReturn('1.0');
+        $requestHeaders->set('X-Experience-API-Version', '1.0.0')->shouldBeCalled();
+
+        $this->onKernelRequest($getResponseEvent);
+    }
+
     function it_returns_null_if_version_is_supported(GetResponseEvent $getResponseEvent, HeaderBag $requestHeaders)
     {
         $requestHeaders->get('X-Experience-API-Version')->shouldBeCalled()->willReturn('1.0.0');


### PR DESCRIPTION
As specified here : https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Communication.md#33-versioning