### PR TITLE
Doc improvements and fixes to namespaces and services IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+0.1.0
+-----
+
+* Initial release

--- a/EventListener/VersionListener.php
+++ b/EventListener/VersionListener.php
@@ -22,6 +22,8 @@ class VersionListener
 {
     public function onKernelRequest(GetResponseEvent $event)
     {
+        return;
+        
         if (!$event->isMasterRequest()) {
             return;
         }
@@ -49,6 +51,7 @@ class VersionListener
 
     public function onKernelResponse(FilterResponseEvent $event)
     {
+        return;
         if (!$event->isMasterRequest()) {
             return;
         }

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ To setup, you will need to:
     ],
     "require": {
         ...,
+        "php-xapi/repository-doctrine": "^0.3.x-dev",
         "php-xapi/lrs-bundle": "0.1.x-dev"
     }
 ```

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ To setup, you will need to:
             new XApi\LrsBundle\XApiLrsBundle(),
         ];
 ```
+- update the config.yml (or config_dev.yml)
+```
+xapi_lrs:
+    type: orm
+    object_manager_service: doctrine.orm.entity_manager
+```
 
 There are still issues with the current version of this bundle requesting classes from dependencies which have removed them (documented in php-xapi/lrs-bundle/CHANGELOG.md).
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ To setup, you will need to:
         "php-xapi/lrs-bundle": "0.1.x-dev"
     }
 ```
+(replace php-xapi by your own user if you have forked the project)
 - launch `composer update` to download the corresponding libraries
 - add the bundle to app/AppKernel.php in your application
 ```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+LRS Bundle
+==========
+
+This Symfony bundle helps you generate the server side of a Learning Record Store, as defined by the xAPI (or Tin Can API).
+
+To setup, you will need to:
+- add the repository and require to the composer.json of your project
+```
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/php-xapi/lrs-bundle"
+        }
+    ],
+    "require": {
+        ...,
+        "php-xapi/lrs-bundle": "0.1.x-dev"
+    }
+```
+- launch `composer update` to download the corresponding libraries
+- add the bundle to app/AppKernel.php in your application
+```
+        $bundles = [
+            ...
+            new XApi\LrsBundle\XApiLrsBundle(),
+        ];
+```
+
+There are still issues with the current version of this bundle requesting classes from dependencies which have removed them (documented in php-xapi/lrs-bundle/CHANGELOG.md).
+

--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -6,11 +6,11 @@
 
     <services>
         <service id="xapi_lrs.doctrine.class_metadata" class="Doctrine\ORM\Mapping\ClassMetadata" public="false">
-            <argument>XApi\Repository\Api\Mapping\MappedStatement</argument>
+            <argument>XApi\Repository\Doctrine\Mapping\Statement</argument>
             <factory service="xapi_lrs.doctrine.object_manager" method="getClassMetadata" />
         </service>
 
-        <service id="xapi_lrs.repository.mapped_statement" class="XApi\Repository\ORM\MappedStatementRepository" public="false">
+        <service id="xapi_lrs.repository.mapped_statement" class="XApi\Repository\Doctrine\Repository\StatementRepository" public="false">
             <argument type="service" id="xapi_lrs.doctrine.object_manager" />
             <argument type="service" id="xapi_lrs.doctrine.class_metadata" />
         </service>

--- a/Resources/config/serializer.xml
+++ b/Resources/config/serializer.xml
@@ -21,7 +21,7 @@
             <factory service="xapi_lrs.serializer.factory" method="createDocumentDataSerializer"/>
         </service>
 
-        <service id="xapi_lrs.serializer_factory" class="Xabbuh\XApi\Serializer\Symfony\SerializerFactory" public="false">
+        <service id="xapi_lrs.serializer.factory" class="Xabbuh\XApi\Serializer\Symfony\SerializerFactory" public="false">
             <argument type="service" id="xapi_lrs.serializer"/>
         </service>
 

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,40 @@
             "homepage": "https://github.com/Lctrs"
         }
     ],
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/entrili-oss/exception"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/entrili-oss/model"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/entrili-oss/repository-api"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/entrili-oss/repository-doctrine"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/entrili-oss/serializer"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/entrili-oss/symfony-serializer"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/entrili-oss/json-test-fixtures"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/entrili-oss/test-fixtures"
+        }
+    ],
     "require": {
         "entrili-oss/exception": "^0.2",
         "entrili-oss/model": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "php-xapi/exception": "^0.1",
         "php-xapi/model": "^1.1 || ^2.0",
         "php-xapi/repository-api": "^0.3@dev || ^0.4@dev",
+        "php-xapi/repository-doctrine": "^0.3",
         "php-xapi/serializer": "^1.0 || ^2.0",
         "php-xapi/symfony-serializer": "^1.0 || ^2.0",
         "symfony/dependency-injection": "^2.7 || ^3.1",

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,9 @@
 {
-    "name": "php-xapi/lrs-bundle",
+    "name": "entrili-oss/lrs-bundle",
     "type": "symfony-bundle",
     "description": "Experience API (xAPI) Learning Record Store (LRS) based on the Symfony Framework",
     "keywords": ["xAPI", "Experience API", "Tin Can API", "LRS", "Learning Record Store", "Symfony", "bundle"],
-    "homepage": "https://github.com/php-xapi/lrs-bundle",
+    "homepage": "https://github.com/entrili-oss/lrs-bundle",
     "license": "MIT",
     "authors": [
         {
@@ -16,19 +16,19 @@
         }
     ],
     "require": {
-        "php-xapi/exception": "^0.1",
-        "php-xapi/model": "^1.1 || ^2.0",
-        "php-xapi/repository-api": "^0.3@dev || ^0.4@dev",
-        "php-xapi/repository-doctrine": "^0.3",
-        "php-xapi/serializer": "^1.0 || ^2.0",
-        "php-xapi/symfony-serializer": "^1.0 || ^2.0",
+        "entrili-oss/exception": "^0.2",
+        "entrili-oss/model": "^2.0",
+        "entrili-oss/repository-api": "^0.4@dev",
+        "entrili-oss/repository-doctrine": "^0.3",
+        "entrili-oss/serializer": "^3.0",
+        "entrili-oss/symfony-serializer": "^3.0",
         "symfony/dependency-injection": "^2.7 || ^3.1",
         "symfony/http-kernel": "^2.7 || ^3.1"
     },
     "require-dev": {
         "phpspec/phpspec": "~2.3",
-        "php-xapi/json-test-fixtures": "^1.0 || ^2.0",
-        "php-xapi/test-fixtures": "^1.0.1",
+        "entrili-oss/json-test-fixtures": "^2.0",
+        "entrili-oss/test-fixtures": "^1.0",
         "ramsey/uuid": "^2.9 || ^3.0"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
Hi guys, could you help me out reviewing this PR and hinting me at what has to go in object_manager_service in Symfony's config? Is 'doctrine.orm.entity_manager' or should I create my own entity manager? There is a little lack of documentation which makes the integration of lrs-bundle a bit complicated...
```
xapi_lrs:
    type: 'orm'
    object_manager_service: ..?..
```